### PR TITLE
:sparkles: Disable purchase button when unavailable

### DIFF
--- a/app/views/games/show.html.slim
+++ b/app/views/games/show.html.slim
@@ -27,10 +27,14 @@
                     = @game.price.discount_percentage
                     | % OFF
               .text-center.mb-10
-                = link_to  @game.price.current_price.formatted,  @game.price.eshop_url,
-                  class: 'btn btn-primary btn-rounded font-weight-bold text-white shadow',
-                  target: '_blank',
-                  rel: "noopener noreferrer"
+                - if @game.coming_soon && !@game.pre_order
+                  .btn.btn-rounded.font-weight-bold.shadow.disabled = @game.price.current_price.formatted
+                  .text-center.text-muted.font-size-12.mt-5 => t('.unavailable_purchase')
+                - else
+                  = link_to  @game.price.current_price.formatted,  @game.price.eshop_url,
+                    class: 'btn btn-primary btn-rounded font-weight-bold text-white shadow',
+                    target: '_blank',
+                    rel: "noopener noreferrer"
               - if @game.price.discount?
                 .text-center.text-muted.font-size-12.font-weight-bold.mb-5
                   = t('.ends_in', time: time_ago_in_words(@game.price.discount_ends_at))

--- a/config/locales/pt-BR/pages/games.yml
+++ b/config/locales/pt-BR/pages/games.yml
@@ -24,6 +24,7 @@ pt-BR:
       genres: Gêneros
       languages: Idiomas disponíveis
       price_history: Histórico de Preços
+      unavailable_purchase: Compra indisponível
 
     list:
       result_count:


### PR DESCRIPTION
Disable purchase button when the purchase is unavailable. It seems to happen on games that are coming soon but not on pre-order yet.

https://github.com/stephannv/nindika/issues/103